### PR TITLE
Remove NPM publish GH action workflow

### DIFF
--- a/.github/workflows/NPM.yml
+++ b/.github/workflows/NPM.yml
@@ -25,18 +25,3 @@ jobs:
       - name: "cat package.json after"
         run: cat ./package.json
 
-  build:
-    runs-on: ubuntu-latest
-    needs: bump-version
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          ref: master
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: npm install
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Workflow was failing, possibly due to secret token not having been setup since moving repo from Jocke's private one to Symptoms. However the NPM registry isn't used anyway since we point out the Github repo when using it in Patient.